### PR TITLE
Ensure that the liblwgeom dependency is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Install the PostGIS lightweight geometry library dependency.
+
 ## 0.1.0
 
 - Initial release.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,4 +9,5 @@
 - name: Install PostGIS
   apt: pkg={{ item }} state=present
   with_items:
+    - liblwgeom-2.1.2={{ postgis_package_version }}
     - postgresql-{{ postgresql_version }}-postgis-{{ postgis_version }}={{ postgis_package_version }}


### PR DESCRIPTION
Trying to execute `CREATE EXTENSION posts;` failed at runtime because the liblwgeom dependency is not available. After installing liblwgeom, the following commands complete successfully inside a `psql` shell:

```
CREATE EXTENSION postgis;
CREATE EXTENSION postgis_topology;
```
