### PR TITLE
Add support for passing an explicit liblwgeom version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ An Ansible role for installing [PostGIS](http://postgis.net).
 ## Role Variables
 
 - `postgis_version` - PostGIS version (default: `2.1`)
-- `postgis_package_version` - PostgreSQL package version (default: `2.1.2+dfsg-2`)
+- `postgis_package_version` - PostGIS package version (default: `2.1.2+dfsg-2`)
+- `postgis_liblwgeom_version` - `liblwgeom` version (default: `2.1.2`)
+- `postgis_liblwgeom_package_version`: liblwgeom package (default: `2.1.2+dfsg-2`)
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 postgis_version: "2.1"
 postgis_package_version: "2.1.2+dfsg-2"
+postgis_liblwgeom_version: "2.1.2"
+postgis_liblwgeom_package_version: "2.1.2+dfsg-2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,5 +9,5 @@
 - name: Install PostGIS
   apt: pkg={{ item }} state=present
   with_items:
-    - liblwgeom-2.1.2={{ postgis_package_version }}
+    - liblwgeom-{{ postgis_liblwgeom_version }}={{ postgis_liblwgeom_package_version }}
     - postgresql-{{ postgresql_version }}-postgis-{{ postgis_version }}={{ postgis_package_version }}


### PR DESCRIPTION
This changeset adds two variables that allow you to explicitly set the `liblwgeom` version, along with a `liblwgeom` package version.