### PR TITLE
Remove explicit install of liblwgeom

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ An Ansible role for installing [PostGIS](http://postgis.net).
 
 - `postgis_version` - PostGIS version (default: `2.1`)
 - `postgis_package_version` - PostGIS package version (default: `2.1.2+dfsg-2`)
-- `postgis_liblwgeom_version` - `liblwgeom` version (default: `2.1.2`)
-- `postgis_liblwgeom_package_version`: liblwgeom package (default: `2.1.2+dfsg-2`)
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,3 @@
 ---
 postgis_version: "2.1"
-postgis_package_version: "2.1.2+dfsg-2"
-postgis_liblwgeom_version: "2.1.2"
-postgis_liblwgeom_package_version: "2.1.2+dfsg-2"
+postgis_package_version: "2.1.5+dfsg-1~exp2~90.git884bcd4.pgdg14.04+1"

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,4 +1,9 @@
 ---
 - hosts: all
+
+  vars:
+    postgresql_version: "9.3"
+    postgresql_package_version: "9.3.5-2.pgdg14.04+1"
+
   roles:
     - { role: "azavea.postgis" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,5 +9,4 @@
 - name: Install PostGIS
   apt: pkg={{ item }} state=present
   with_items:
-    - liblwgeom-{{ postgis_liblwgeom_version }}={{ postgis_liblwgeom_package_version }}
     - postgresql-{{ postgresql_version }}-postgis-{{ postgis_version }}={{ postgis_package_version }}


### PR DESCRIPTION
This changeset removes the explicit installation of liblwgeom now that it appears that the PostGIS package handles pulling in the version of liblwgeom it depends on.

This avoids the runtime error from before that led to the explicit installation of liblwgeom in this Ansible role. It also avoids a nasty edge case where liblwgeom pulls in PostgreSQL 9.4 as a dependency despite already having PostgreSQL 9.3 installed.