### PR TITLE
Glob version for install; test PostgreSQL 9.4 support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 postgis_version: "2.1"
-postgis_package_version: "2.1.5+dfsg-1~exp2~90.git884bcd4.pgdg14.04+1"
+postgis_package_version: "2.1.*.pgdg14.04+1"

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,1 +1,1 @@
-azavea.postgresql,0.1.1
+azavea.postgresql,0.3.0

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -2,8 +2,8 @@
 - hosts: all
 
   vars:
-    postgresql_version: "9.3"
-    postgresql_package_version: "9.3.5-2.pgdg14.04+1"
+    postgresql_version: "9.4"
+    postgresql_package_version: "9.4.*-1.pgdg14.04+1"
 
   roles:
     - { role: "azavea.postgis" }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: An Ansible role for installing PostGIS.
   company: Azavea Inc.
   license: Apache
-  min_ansible_version: 1.2
+  min_ansible_version: 1.8
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
In the process of testing PostgreSQL 9.4 support for PostGIS 2.1, I also made the default version a glob for flexibility.

Depends on: https://github.com/azavea/ansible-postgresql/pull/4