### PR TITLE
Switch example from roles.txt to roles.yml

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 # Ensure role dependencies are in place
 if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
   !(File.directory?("roles/azavea.postgresql") || File.symlink?("roles/azavea.postgresql"))
-  system("ansible-galaxy install --force -r roles.txt -p roles")
+  system("ansible-galaxy install --force -r roles.yml -p roles")
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,1 +1,0 @@
-azavea.postgresql,0.3.0

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,0 +1,2 @@
+- src: azavea.postgresql
+  version: 0.3.0

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -3,7 +3,7 @@
 
   vars:
     postgresql_version: "9.4"
-    postgresql_package_version: "9.4.*-1.pgdg14.04+1"
+    postgresql_package_version: "9.4.*-2.pgdg14.04+1"
 
   roles:
     - { role: "azavea.postgis" }


### PR DESCRIPTION
The CSV format is deprecated as of Ansible 2.0.

This PR also updates the Postgres package version variable becase 9.4.*-1 is no longer available in the repository.
##### Testing

Destroy and recreate the example VM after deleting any previously downloaded roles.

$ cd examples
$ rm -rf roles/azavea.postgresql
$ vagrant destroy -f && vagrant up
